### PR TITLE
Update config.py prompts import

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -1,6 +1,6 @@
 import yaml
 from easydict import EasyDict as edict
-from langchain import PromptTemplate
+from langchain.prompts import PromptTemplate
 from langchain.chat_models import ChatOpenAI
 from pathlib import Path
 from langchain.llms.huggingface_pipeline import HuggingFacePipeline


### PR DESCRIPTION
this removes a user warning and seems to be working without any difference
`langchain/__init__.py:34: UserWarning: Importing PromptTemplate from langchain root module is no longer supported. Please use langchain.prompts.PromptTemplate instead.`