### PR TITLE
Update base_dataset.py pandas append

### DIFF
--- a/dataset/base_dataset.py
+++ b/dataset/base_dataset.py
@@ -52,8 +52,8 @@ class DatasetBase:
         :param records: dataframes, update using pandas
         """
         if records is None:
-            records = [{'id': len(self.records) + i, 'text': sample, 'batch_id': batch_id} for
-                       i, sample in enumerate(sample_list)]
+            records = pd.DataFrame([{'id': len(self.records) + i, 'text': sample, 'batch_id': batch_id} for
+                       i, sample in enumerate(sample_list)])
         self.records = pd.concat([self.records, records], ignore_index=True)
 
     def update(self, records: pd.DataFrame):


### PR DESCRIPTION
this removes a more serious future warning of a deprecated method in pandas
```
AutoPrompt/dataset/base_dataset.py:53: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  self.records = self.records.append(records, ignore_index=True)
```