### PR TITLE
removing rounding for eval

### DIFF
--- a/utils/eval.py
+++ b/utils/eval.py
@@ -29,7 +29,7 @@ class Eval:
         """
         dataset.apply(self.score_func, column_name='score')
         valid_data = dataset.records.dropna(subset=['annotation', 'prediction'])
-        self.mean_score = round(valid_data['score'].mean(), 2)
+        self.mean_score = valid_data['score'].mean()
 
     def get_min_score(self):
         """


### PR DESCRIPTION
score should be rounded only when used in the prompt string, and the full precision should be kept throughout the rest of the procedure. otherwise there might be a degeneracy between epochs

NOTE
this pr should be merged _after_ the generation pr is merged (https://github.com/Eladlev/AutoPrompt/pull/9)