### PR TITLE
fix issues with Azure Openai endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas==1.5.3
 tqdm==4.66.1
 prodict==0.8.18
 langchain==0.1.9
-openai==0.28.0
+openai==1.1.0
 tiktoken==0.5.1
 easydict==1.11
 wandb==0.16.0

--- a/utils/config.py
+++ b/utils/config.py
@@ -36,18 +36,20 @@ def get_llm(config: dict):
     if config['type'] == 'OpenAI':
         if LLM_ENV['openai']['OPENAI_ORGANIZATION'] == '':
             return ChatOpenAI(temperature=temperature, model_name=config['name'],
-                              openai_api_key=LLM_ENV['openai']['OPENAI_API_KEY'],
+                              openai_api_key=config.get('openai_api_key', LLM_ENV['openai']['OPENAI_API_KEY']),
+                              openai_api_base=config.get('openai_api_base', 'https://api.openai.com/v1'),
                               model_kwargs=model_kwargs)
         else:
             return ChatOpenAI(temperature=temperature, model_name=config['name'],
-                              openai_api_key=LLM_ENV['openai']['OPENAI_API_KEY'],
-                              openai_organization=LLM_ENV['openai']['OPENAI_ORGANIZATION'],
+                              openai_api_key=config.get('openai_api_key', LLM_ENV['openai']['OPENAI_API_KEY']),
+                              openai_api_base=config.get('openai_api_base', 'https://api.openai.com/v1'),
+                              openai_organization=config.get('openai_organization', LLM_ENV['openai']['OPENAI_ORGANIZATION']),
                               model_kwargs=model_kwargs)
     elif config['type'] == 'Azure':
-        return AzureChatOpenAI(temperature=temperature, deployment_name=config['name'],
-                        openai_api_key=LLM_ENV['azure']['AZURE_OPENAI_API_KEY'],
-                        azure_endpoint=LLM_ENV['azure']['AZURE_OPENAI_ENDPOINT'],
-                        openai_api_version=LLM_ENV['azure']['OPENAI_API_VERSION'])
+        return AzureChatOpenAI(temperature=temperature, azure_deployment=config['name'],
+                        openai_api_key=config.get('openai_api_key', LLM_ENV['azure']['AZURE_OPENAI_API_KEY']),
+                        azure_endpoint=config.get('azure_endpoint', LLM_ENV['azure']['AZURE_OPENAI_ENDPOINT']),
+                        openai_api_version=config.get('openai_api_version', LLM_ENV['azure']['OPENAI_API_VERSION']))
 
     elif config['type'] == 'Google':
         from langchain_google_genai import ChatGoogleGenerativeAI

--- a/utils/llm_chain.py
+++ b/utils/llm_chain.py
@@ -153,7 +153,7 @@ class ChainWrapper:
         """
         Build the chain according to the LLM type
         """
-        if self.llm_config.type == 'OpenAI' and self.json_schema is not None:
+        if (self.llm_config.type == 'OpenAI' or self.llm_config.type == 'Azure') and self.json_schema is not None:
             self.chain = create_structured_output_runnable(self.json_schema, self.llm, self.prompt)
         else:
             self.chain = LLMChain(llm=self.llm, prompt=self.prompt)


### PR DESCRIPTION
I find some issues working with Azure OpenAI endpoint.

## Issue 1
in the llm_env.yml, it's only allowed set one AZURE_OPENAI_ENDPOINT for azure type llm and not allowed to set openai_api_base.

this will causes:
<br>-  azure openai deployments may deployed within different azure endpoints. For example, gpt-4 are only available in some regions, and gpt-35-turbo in others.
<br>- in langchain, [vLLM Chat](https://python.langchain.com/docs/integrations/chat/vllm) is supported via ChatOpenAI, the openai_base should be exposed for configuration.

## Solution 1
By allowing set specific attributes in the config yml file, we give more control to the llm endpoints.

## Issue 2
openai version in requiremnts.txt is not compatible with langchain when working at azure endpoint.

## Solution
update openai package version to 1.1.0

## Issue 3
there is no available parser if the llm type is not OpenAI in output_schemas of meta_prompts_classification. This causes the generated response unable to parsed when llm type is Azure.

## Solution
Since Azure support the json schema, just leverage create_structured_output_runnable when llm type is OpenAI or Azure.



