### PR TITLE
Change `gpt-3.5-turbo` from 0613 to 1106

### DIFF
--- a/config/config_default.yml
+++ b/config/config_default.yml
@@ -20,7 +20,7 @@ predictor:
     config:
         llm:
             type: 'OpenAI'
-            name: 'gpt-3.5-turbo-0613'
+            name: 'gpt-3.5-turbo-1106'
 #            async_params:
 #                retry_interval: 10
 #                max_retries: 2

--- a/config/config_diff/config_generation.yml
+++ b/config/config_diff/config_generation.yml
@@ -12,7 +12,7 @@ predictor:
         mini_batch_size: 1
         llm:
             type: 'OpenAI'
-            name: 'gpt-4-1106-preview' #'gpt-3.5-turbo-0613'
+            name: 'gpt-4-1106-preview' #'gpt-3.5-turbo-1106'
         num_workers: 7
 
 meta_prompts:


### PR DESCRIPTION
On `config_default.yml`, `gpt-3.5-turbo-0613` has been deprecated from the OpenAI API, so I've changed it into `gpt-3.5-turbo-1106` to make it consistent with `gpt-4-1106-preview`.

I've also updated it in `config/config_diff/config_generation.yml` as well.