### PR TITLE
Removed duplicated `ChainWrapper` import

### DIFF
--- a/metric_generator/metric_gen.py
+++ b/metric_generator/metric_gen.py
@@ -1,5 +1,4 @@
 from utils.llm_chain import ChainWrapper
-from utils.llm_chain import ChainWrapper
 from langchain_core.pydantic_v1 import BaseModel, Field
 
 


### PR DESCRIPTION
I noticed that we invoked 'from utils.llm_chain import ChainWrapper' twice in 'metric_generator/metric_gen.py', so I removed one of the invocations.