### PR TITLE
Fix Bug for custom-OpenAI-API Endpoint and install correct version of huggingface-hub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ langchain-anthropic==0.3.0
 langchain-community==0.3.7
 langchain-google-genai==2.0.4
 pillow==10.2.0
+huggingface_hub==0.24.7

--- a/utils/config.py
+++ b/utils/config.py
@@ -35,15 +35,16 @@ def get_llm(config: dict):
         model_kwargs = {}
 
     if config['type'].lower() == 'openai':
+        api_base = LLM_ENV['openai']['OPENAI_API_BASE'] if LLM_ENV['openai']['OPENAI_API_BASE'] != '' else 'https://api.openai.com/v1'
         if LLM_ENV['openai']['OPENAI_ORGANIZATION'] == '':
             return ChatOpenAI(temperature=temperature, model_name=config['name'],
                               openai_api_key=config.get('openai_api_key', LLM_ENV['openai']['OPENAI_API_KEY']),
-                              openai_api_base=config.get('openai_api_base', 'https://api.openai.com/v1'),
+                              openai_api_base=config.get('openai_api_base', api_base),
                               model_kwargs=model_kwargs)
         else:
             return ChatOpenAI(temperature=temperature, model_name=config['name'],
                               openai_api_key=config.get('openai_api_key', LLM_ENV['openai']['OPENAI_API_KEY']),
-                              openai_api_base=config.get('openai_api_base', 'https://api.openai.com/v1'),
+                              openai_api_base=config.get('openai_api_base', api_base),
                               openai_organization=config.get('openai_organization', LLM_ENV['openai']['OPENAI_ORGANIZATION']),
                               model_kwargs=model_kwargs)
     elif config['type'].lower() == 'azure':


### PR DESCRIPTION
Hi there,

Nice work on this repo!

After the fix you provided yesterday, I found that sentence-transformer and other packages were still importing `(cache_..)` from huggingface_hub, so I added a working version of the lib to the requirements. I also tried to use a custom endpoint and it defaulted to the openai, one because the backup for the config is not the value from the LLM config.